### PR TITLE
修复Apollo无法请求到后台的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+# .env
 .venv
 env/
 venv/

--- a/osscs-web/.env
+++ b/osscs-web/.env
@@ -1,0 +1,2 @@
+VUE_APP_GRAPHQL_SERVER_URI_DOCKER='http://osscs:8000/graphql/'
+VUE_APP_GRAPHQL_SERVER_URI='http://localhost:8000/graphql/'

--- a/osscs-web/deploy/nginx.conf
+++ b/osscs-web/deploy/nginx.conf
@@ -27,7 +27,7 @@ server {
     #     alias /usr/share/nginx/html/media; # 媒体资源，用户上传文件路径
     # }
 
-    location ^~/(api|graphql)/ {
+    location ^~/api/ {
         include uwsgi_params;
         uwsgi_pass django;
         # uwsgi_params UWSGI_SCRIPT osscs.wsgi
@@ -39,6 +39,13 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_redirect off;
         proxy_set_header X-Real-IP  $remote_addr;
-       # proxy_pass http://django;  # 使用uwsgi通信，而不是http，所以不使用proxy_pass。
+        # proxy_pass http://django;  # 使用uwsgi通信，而不是http，所以不使用proxy_pass。
+    }
+
+    location ^~/graphql/ {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_redirect off;
+        proxy_set_header X-Real-IP  $remote_addr;
+        proxy_pass http://django;  # 使用uwsgi通信，而不是http，所以不使用proxy_pass。
     }
 }

--- a/osscs-web/src/utils/apollo.js
+++ b/osscs-web/src/utils/apollo.js
@@ -1,19 +1,44 @@
-import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client/core'
+import { ApolloClient, createHttpLink, InMemoryCache, from } from '@apollo/client/core'
 import { createApolloProvider } from '@vue/apollo-option'
+import { onError } from "@apollo/client/link/error";
 
-
+// 浏览器访问在docker意外，无法解析域名，因此在此动态指定graphql的uri
+let apiEndpoint;
+if (process.env.NODE_ENV == 'development') {
+  apiEndpoint = "http://localhost:8000/graphql/";
+} else {
+  if (typeof window !== 'undefined') {
+    // 外部浏览器访问
+    apiEndpoint = process.env.VUE_APP_GRAPHQL_SERVER_URI;
+  }
+  else {
+    // docker 内部访问
+    apiEndpoint = process.env.VUE_APP_GRAPHQL_SERVER_URI_DOCKER;
+  }
+}
 // 与 API 的 HTTP 连接
 const httpLink = createHttpLink({
   // 你需要在这里使用绝对路径
-  uri: 'http://127.0.0.1:8000/graphql/',
+  uri: apiEndpoint,
 })
+
+// Log any GraphQL errors or network error that occurred
+const errorLink = onError(({ graphQLErrors, networkError }) => {
+  if (graphQLErrors)
+    graphQLErrors.forEach(({ message, locations, path }) =>
+      console.log(
+        `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`
+      )
+    );
+  if (networkError) console.log(`[Network error]: ${networkError}`);
+});
 
 // 缓存实现
 const cache = new InMemoryCache()
 
 // 创建 apollo 客户端
 const apolloClient = new ApolloClient({
-  link: httpLink,
+  link: from([errorLink, httpLink]),
   cache,
 })
 

--- a/osscs/osscs/settings.py
+++ b/osscs/osscs/settings.py
@@ -36,7 +36,8 @@ CORS_ORIGIN_ALLOW_ALL = False
 CORS_ORIGIN_WHITELIST = ("http://127.0.0.1:8080",
                          "http://localhost:8080",
                          "http://127.0.0.1",
-                         "http://localhost",)
+                         "http://localhost",
+                         "http://nginx")
 
 # Application definition
 

--- a/osscs/uwsgi.ini
+++ b/osscs/uwsgi.ini
@@ -10,7 +10,7 @@ module=%(project).wsgi:application
 master=True
 processes=1
 
-socket=0.0.0.0:8000
+http-socket=0.0.0.0:8000
 chown-socket=%(uid):www-data
 chmod-socket=664
 


### PR DESCRIPTION
由于用户使用浏览器在docker外部访问grapql接口，因此无法解析到docker内部的服务域名，这里需要判断浏览器请求来源来动态更换接口地址，具体参考[issue](https://github.com/apollographql/apollo-link/issues/375#issuecomment-636283161)